### PR TITLE
Implement game end screen and stats

### DIFF
--- a/damas/core/Jogador.java
+++ b/damas/core/Jogador.java
@@ -31,8 +31,8 @@ public class Jogador implements Serializable {
         return pecasCapturadas;
     }
     
-    public void incrementarPecasCapturadas() {
-        this.pecasCapturadas++;
+    public void incrementarPecasCapturadas(int quantidade) {
+        this.pecasCapturadas += quantidade;
     }
     
     @Override

--- a/damas/core/Tabuleiro.java
+++ b/damas/core/Tabuleiro.java
@@ -111,12 +111,25 @@ public class Tabuleiro implements Serializable {
     public boolean podeMover(Posicao origem, Posicao destino) {
         try {
             Peca peca = getPeca(origem);
-            return peca != null && 
-                   peca.podeMoverPara(destino, this) && 
+            return peca != null &&
+                   peca.podeMoverPara(destino, this) &&
                    getPeca(destino) == null;
         } catch (Exception e) {
             return false;
         }
+    }
+
+    public int contarPecas(CorPeca cor) {
+        int contador = 0;
+        for (int i = 0; i < TAMANHO; i++) {
+            for (int j = 0; j < TAMANHO; j++) {
+                Peca p = grade[i][j];
+                if (p != null && p.getCor() == cor) {
+                    contador++;
+                }
+            }
+        }
+        return contador;
     }
 
     private void validarPosicao(Posicao posicao) throws PosicaoInvalidaException {


### PR DESCRIPTION
## Summary
- add method to count pieces by color
- track captured pieces and winner in `Jogo`
- provide end-of-game modal with statistics and options to save log
- support restarting a new game after saving

## Testing
- `javac $(cat sources.txt)`
- `java -cp bin damas.core.P1`
- `java -cp bin damas.ui.P2` *(fails: No X11 DISPLAY variable was set)*

------
https://chatgpt.com/codex/tasks/task_e_68475d08a6048327a0ea017697e73793