### PR TITLE
Fix capture movement logic

### DIFF
--- a/damas/core/Jogador.java
+++ b/damas/core/Jogador.java
@@ -31,8 +31,8 @@ public class Jogador implements Serializable {
         return pecasCapturadas;
     }
     
-    public void incrementarPecasCapturadas() {
-        this.pecasCapturadas++;
+    public void incrementarPecasCapturadas(int quantidade) {
+        this.pecasCapturadas += quantidade;
     }
     
     @Override

--- a/damas/core/PecaSimples.java
+++ b/damas/core/PecaSimples.java
@@ -1,6 +1,7 @@
 package damas.core;
 
 import damas.exceptions.MovimentoInvalidoException;
+import damas.exceptions.PosicaoInvalidaException;
 
 /**
  * Representa uma peça simples do jogo de damas
@@ -19,17 +20,17 @@ public class PecaSimples extends Peca {
     }
     
     @Override
-    public boolean podeMoverPara(Posicao destino, Tabuleiro tabuleiro) 
+    public boolean podeMoverPara(Posicao destino, Tabuleiro tabuleiro)
             throws MovimentoInvalidoException {
         
         int diferencaLinha = destino.getLinha() - posicao.getLinha();
-        int diferencaColuna = Math.abs(destino.getColuna() - posicao.getColuna());
+        int diferencaColuna = destino.getColuna() - posicao.getColuna();
         
         // Peça simples só move na diagonal
-        if (diferencaColuna != Math.abs(diferencaLinha)) {
+        if (Math.abs(diferencaColuna) != Math.abs(diferencaLinha)) {
             throw new MovimentoInvalidoException("Peça simples só pode mover na diagonal");
         }
-        
+
         // Movimento simples (1 casa) ou captura (2 casas)
         if (Math.abs(diferencaLinha) == 1) {
             // Movimento simples - verifica direção baseada na cor
@@ -39,18 +40,38 @@ public class PecaSimples extends Peca {
             } else {
                 direcaoCorreta = diferencaLinha > 0; // Pretas descem
             }
-            
+
             if (!direcaoCorreta) {
                 throw new MovimentoInvalidoException("Peça simples não pode mover para trás (só capturas)");
             }
+
+            try {
+                if (tabuleiro.getPeca(destino) != null) {
+                    throw new MovimentoInvalidoException("Destino ocupado");
+                }
+            } catch (PosicaoInvalidaException e) {
+                throw new MovimentoInvalidoException("Posição inválida", e);
+            }
         } else if (Math.abs(diferencaLinha) == 2) {
-            // CAPTURA - PODE SER EM QUALQUER DIREÇÃO (inclusive para trás!)
-            // Peças simples podem capturar para trás nas damas tradicionais
-            return true;
+            int meioLinha = (posicao.getLinha() + destino.getLinha()) / 2;
+            int meioColuna = (posicao.getColuna() + destino.getColuna()) / 2;
+            Posicao meio = new Posicao(meioLinha, meioColuna);
+
+            try {
+                Peca p = tabuleiro.getPeca(meio);
+                if (p == null || p.getCor() == this.cor) {
+                    throw new MovimentoInvalidoException("Captura inválida");
+                }
+                if (tabuleiro.getPeca(destino) != null) {
+                    throw new MovimentoInvalidoException("Destino ocupado");
+                }
+            } catch (PosicaoInvalidaException e) {
+                throw new MovimentoInvalidoException("Posição inválida", e);
+            }
         } else {
             throw new MovimentoInvalidoException("Peça simples só pode mover 1 ou 2 casas");
         }
-        
+
         return true;
     }
 }

--- a/damas/core/Tabuleiro.java
+++ b/damas/core/Tabuleiro.java
@@ -53,6 +53,10 @@ public class Tabuleiro implements Serializable {
             throw new MovimentoInvalidoException("Movimento inválido");
         }
 
+        if (getPeca(destino) != null) {
+            throw new MovimentoInvalidoException("Destino ocupado");
+        }
+
         // Trata captura (para damas)
         int diffLinha = Math.abs(destino.getLinha() - origem.getLinha());
         if (diffLinha >= 2) {
@@ -111,12 +115,25 @@ public class Tabuleiro implements Serializable {
     public boolean podeMover(Posicao origem, Posicao destino) {
         try {
             Peca peca = getPeca(origem);
-            return peca != null && 
-                   peca.podeMoverPara(destino, this) && 
+            return peca != null &&
+                   peca.podeMoverPara(destino, this) &&
                    getPeca(destino) == null;
         } catch (Exception e) {
             return false;
         }
+    }
+
+    public int contarPecas(CorPeca cor) {
+        int contador = 0;
+        for (int i = 0; i < TAMANHO; i++) {
+            for (int j = 0; j < TAMANHO; j++) {
+                Peca p = grade[i][j];
+                if (p != null && p.getCor() == cor) {
+                    contador++;
+                }
+            }
+        }
+        return contador;
     }
 
     private void validarPosicao(Posicao posicao) throws PosicaoInvalidaException {


### PR DESCRIPTION
## Summary
- prevent moving onto occupied squares in `Tabuleiro.moverPeca`
- enforce proper capture rules in `PecaSimples.podeMoverPara`

## Testing
- `javac $(cat sources.txt)`
- `java -cp bin damas.core.P1`
- `java -cp bin damas.ui.P2` *(fails: No X11 DISPLAY variable was set)*

------
https://chatgpt.com/codex/tasks/task_e_68475d08a6048327a0ea017697e73793